### PR TITLE
[!!/ED] Edit of first section (see comments and edits)

### DIFF
--- a/source/accessible-media/index.html.erb.md
+++ b/source/accessible-media/index.html.erb.md
@@ -20,15 +20,15 @@ contributors:
 support: Developed with support from the <a href="https://www.w3.org/WAI/WCAGTA/">U.S. Access Board, WCAG TA Project</a>
 ---
 
-Captions, audio descriptions and transcripts make online media accessible to people with disabilities. This tutorial will demonstrate how to add captions, audio descriptions and transcripts to video and audio clips. Other accessibility approaches, such as the inclusion of foreign-language subtitles, are also described.
+Captions, audio descriptions, and transcripts are required to make video and audio media accessible to people with disabilities. This tutorial demonstrates how to add captions, subtitles, audio descriptions, and transcripts to video and audio.
 
--   [**Captions**](production-captions.html) provide a text version of the video’s dialogue, narration, or other spoken words. They are synchronized with the program audio and displayed within the media player. Captions also include text identifying non-speech information, such as music and sound effects.
+-   [**Captions**](production-captions.html) are a text version of audio, including dialogue, narration, and non-speech information such as music and sound effects. Captions are synchronized with the audio and displayed within the media player.
 
--   [**Subtitles**](subtitles.html) are a synchronized text version of a media’s audio track, translated into another language.
+-   [**Subtitles**](subtitles.html) are a text version of the dialogue and narration translated into another language. Subtitles are synchronized with the audio and displayed within the media player.
 
--   [**Transcripts**](transcript.html) are a text version of a video’s audio track, containing narration, dialog and non-speech information such as speaker-identification cues. Transcripts can be static or interactive documents. Interactive transcripts can be synchronized with the media: words are highlighted automatically as they are spoken, or users can select words to move to that spot in the video.  Transcripts are crucial for users who are deaf-blind, or for any user who relies on braille.
+-   [**Transcripts**](transcript.html) are a text version of audio, including dialogue, narration, and speaker identification. Some transcripts include non-speech audio information. Transcripts can be static or interactive. Interactive transcripts can be synchronized with the media so that words are highlighted as they are spoken, and users can select words to move to that spot in the video.
 
--   [**Audio descriptions**](production-audio-description.html) are an extra track of narration (audio or text) that conveys information about important visuals, such as body language, changes in scenery and context, charts and diagrams.
+-   [**Audio descriptions**](production-audio-description.html) are an audio or text version of important visual information, such as body language, changes in scenery and context, charts, and diagrams. Audio descriptions are usually provided in a separate audio track.
 
 ## What are high-quality captions and audio descriptions?
 


### PR DESCRIPTION
Edited bullets to have parallel structure and word order. Tersified and simplified language. Fixed oxford comma.

I suggested "video and audio media" in the first sentence to help tie the title "Accessible Media" to "video and audio"

Deleted "Transcripts are crucial for users who are deaf-blind, or for any user who relies on braille." because that belongs in earlier or later section, not this description bullet.

Consider deleting "Interactive transcripts can be synchronized with the media so that words are highlighted as they are spoken, and users can select words to move to that spot in the video." from this **short** description. It can be more clearly covered in the specific section.

Overall I guess most of this is editor's discretion, yet *highly* recommended. :-)